### PR TITLE
Don't allow reply keyboard shortcut while no active topic

### DIFF
--- a/packages/client/src/pages/MeetingPage.tsx
+++ b/packages/client/src/pages/MeetingPage.tsx
@@ -129,6 +129,10 @@ function MeetingPageInner() {
   const addQueueEntry = useCallback(
     (type: 'topic' | 'reply' | 'question' | 'point-of-order', placeholder: string) => {
       if (!socket || !meeting) return;
+      // Reply only makes sense against a current topic — match the button's
+      // visibility gate so the `r` shortcut is a no-op when there's nothing
+      // to reply to.
+      if (type === 'reply' && !meeting.current.topic) return;
       // Point of Order is always permitted — procedural interruptions bypass
       // the queue-closed gate for non-chairs.
       if (meeting.queue.closed && !isChair && type !== 'point-of-order') return;

--- a/packages/server/src/socket.test.ts
+++ b/packages/server/src/socket.test.ts
@@ -931,6 +931,29 @@ describe('Socket.IO integration', () => {
       expect(ctx.meetingManager.get(meetingId)!.queue.orderedIds).toHaveLength(1);
     });
 
+    it('rejects a reply when there is no current topic at all', async () => {
+      // Don't drive to a current.topic state — just join a fresh meeting so
+      // current.topic is null. A client that sends `currentTopicSpeakerId: null`
+      // in this state must not be allowed to add a reply (matches with null
+      // would pass the equality check on its own).
+      const owner = { ghid: 1, ghUsername: 'testuser', name: 'Test User', organisation: 'Test Org' };
+      const meeting = ctx.meetingManager.create([owner]);
+      const client = await joinMeeting(meeting.id);
+
+      const errorPromise = waitForEvent<string>(client, 'error');
+      const ackPromise = new Promise<{ ok: boolean; error?: string }>((resolve) => {
+        client.emit('queue:add', { type: 'reply', topic: 'No topic reply', currentTopicSpeakerId: null }, resolve);
+      });
+
+      const error = await errorPromise;
+      const ack = await ackPromise;
+
+      expect(error).toMatch(/no topic is currently active/i);
+      expect(ack.ok).toBe(false);
+      expect(ack.error).toMatch(/no topic is currently active/i);
+      expect(ctx.meetingManager.get(meeting.id)!.queue.orderedIds).toHaveLength(0);
+    });
+
     it('bypasses the precondition when the chair adds a reply via asUsername', async () => {
       const { client, meetingId } = await setupWithCurrentTopic();
 
@@ -2337,24 +2360,34 @@ describe('Socket.IO integration', () => {
 
       const client = await joinMeeting(meeting.id);
 
-      // Start meeting
+      // Start meeting — intro speaker is current, no current.topic yet
       let statePromise = waitForChange(client, ctx.meetingManager, meeting.id);
       client.emit('meeting:nextAgendaItem', { currentAgendaItemId: meeting.current.agendaItemId ?? null }, () => {});
       await statePromise;
 
-      // Add a reply and advance to it. current.topic is undefined at this
-      // point (the agenda intro doesn't count as a queued topic), so the
-      // precondition is explicitly null.
+      // Queue a topic and advance to it so current.topic is populated
       statePromise = waitForChange(client, ctx.meetingManager, meeting.id);
-      client.emit('queue:add', { type: 'reply', topic: 'My reply', currentTopicSpeakerId: null });
+      client.emit('queue:add', { type: 'topic', topic: 'My topic' });
       let state = await statePromise;
 
       statePromise = waitForChange(client, ctx.meetingManager, meeting.id);
       client.emit('queue:next', { currentSpeakerEntryId: state.current.speaker?.id ?? null }, () => {});
       state = await statePromise;
 
-      // Reply should be in the same topic group as the intro (not finalised yet)
+      const topicSpeakerId = state.current.topic!.speakerId;
+
+      // Add a reply against the live current.topic and advance to it
+      statePromise = waitForChange(client, ctx.meetingManager, meeting.id);
+      client.emit('queue:add', { type: 'reply', topic: 'My reply', currentTopicSpeakerId: topicSpeakerId });
+      state = await statePromise;
+
+      statePromise = waitForChange(client, ctx.meetingManager, meeting.id);
+      client.emit('queue:next', { currentSpeakerEntryId: state.current.speaker?.id ?? null }, () => {});
+      state = await statePromise;
+
+      // Reply should be in the same topic group as the topic (not finalised yet)
       expect(state.current.topicSpeakers).toHaveLength(2);
+      expect(state.current.topicSpeakers[0].type).toBe('topic');
       expect(state.current.topicSpeakers[1].type).toBe('reply');
       expect(state.current.topicSpeakers[1].topic).toBe('My reply');
     });

--- a/packages/server/src/socket.ts
+++ b/packages/server/src/socket.ts
@@ -919,16 +919,23 @@ export function registerSocketHandlers(
       // Precondition check for replies: the topic the user intended to reply
       // to must still be the current topic. `undefined` in the payload means
       // the client didn't send the precondition — treat that as a mismatch
-      // for replies so stale clients can't silently bypass the guard. The
+      // for replies so stale clients can't silently bypass the guard. There
+      // must also actually be a current topic — a reply with no topic to
+      // reply to is nonsensical regardless of what the client claimed. The
       // asUsername path (chair-driven bulk restore) bypasses this — it's a
       // deliberate admin operation, not a UI race.
       if (parsed.type === 'reply' && !parsed.asUsername) {
         const currentSpeakerId = addMeeting?.current.topic?.speakerId ?? null;
         const claimedSpeakerId = parsed.currentTopicSpeakerId ?? null;
-        if (parsed.currentTopicSpeakerId === undefined || currentSpeakerId !== claimedSpeakerId) {
+        const noActiveTopic = currentSpeakerId === null;
+        const preconditionMismatch =
+          parsed.currentTopicSpeakerId === undefined || currentSpeakerId !== claimedSpeakerId;
+        if (noActiveTopic || preconditionMismatch) {
           // Re-broadcast state to the stale client so it reconciles.
           if (addMeeting) socket.emit('state', decorateMeetingForClient(addMeeting, appSettings));
-          const message = 'Topic has changed — your reply was not added';
+          const message = noActiveTopic
+            ? 'No topic is currently active - you can not reply'
+            : 'Topic has changed — your reply was not added';
           socket.emit('error', message);
           respond({ ok: false, error: message });
           return;


### PR DESCRIPTION
The button was correctly disabled, but the keyboard shortcut still worked.

Now the keyboard shortcut silently no-ops. Additionally the server enforces the limitation now.