### PR TITLE
queue: cool down Next Speaker when the next-up entry changes

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -281,7 +281,7 @@ The user's own queue entries are visually distinguished with a coloured left bor
 - If the queue is empty when advancement occurs, the current speaker is cleared.
 - If a chair's view of the current speaker or current agenda item is out of date when the **Next Speaker** or **Next Agenda Item** action reaches the server (for example, another chair has just advanced), the action is rejected to prevent conflicts.
 - Both the **Next Speaker** and **Next Agenda Item** actions are debounced to ignore rapid repeated activations. After a change triggered by another user is received from the server, the action enters a brief cooldown during which it is disabled (visually greyed out and non-interactive), preventing accidental double-advancement.
-- The **Next Speaker** action additionally enters the same cooldown whenever the next-up queue entry changes (e.g. its owner deletes it, a point-of-order jumps to the front, or the queue is reordered) so the chair can register the new next speaker before clicking again. Self-initiated advances still skip the cooldown.
+- The **Next Speaker** action additionally enters the same cooldown when the entry that was next-up is deleted out of the queue (for example, its owner removes it just as the chair is about to advance). This prevents the chair from accidentally advancing past the intended speaker to whoever shifts into first place. Reordering the queue or inserting a new entry ahead of the next-up one does not trigger the cooldown — only deletion of the next-up entry does.
 
 ### Queue Reordering
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -281,6 +281,7 @@ The user's own queue entries are visually distinguished with a coloured left bor
 - If the queue is empty when advancement occurs, the current speaker is cleared.
 - If a chair's view of the current speaker or current agenda item is out of date when the **Next Speaker** or **Next Agenda Item** action reaches the server (for example, another chair has just advanced), the action is rejected to prevent conflicts.
 - Both the **Next Speaker** and **Next Agenda Item** actions are debounced to ignore rapid repeated activations. After a change triggered by another user is received from the server, the action enters a brief cooldown during which it is disabled (visually greyed out and non-interactive), preventing accidental double-advancement.
+- The **Next Speaker** action additionally enters the same cooldown whenever the next-up queue entry changes (e.g. its owner deletes it, a point-of-order jumps to the front, or the queue is reordered) so the chair can register the new next speaker before clicking again. Self-initiated advances still skip the cooldown.
 
 ### Queue Reordering
 

--- a/packages/client/src/hooks/useAdvanceAction.test.tsx
+++ b/packages/client/src/hooks/useAdvanceAction.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import type { CurrentSpeaker, MeetingState, User } from '@tcq/shared';
+import type { CurrentSpeaker, MeetingState, QueueEntry, User } from '@tcq/shared';
 import { useAdvanceAction } from './useAdvanceAction.js';
 import { MeetingStateContext, MeetingDispatchContext, type MeetingContextState } from '../contexts/MeetingContext.js';
 import { SocketContext, type TypedSocket } from '../contexts/SocketContext.js';
@@ -19,14 +19,24 @@ interface MakeMeetingOverrides {
   speakerId?: string;
   /** Convenience: set operational.lastAdvancementBy. */
   lastAdvancementBy?: string;
+  /** Convenience: populate queue.orderedIds + entries with these ids (as topics by alice). */
+  queueIds?: string[];
+}
+
+function entryWith(id: string): QueueEntry {
+  return { id, type: 'topic', topic: id, userId: 'alice' };
 }
 
 /** Create a minimal meeting state for testing. */
 function makeMeeting(overrides?: MakeMeetingOverrides): MeetingState {
+  const ids = overrides?.queueIds ?? [];
+  const entries: Record<string, QueueEntry> = {};
+  for (const id of ids) entries[id] = entryWith(id);
   return buildMeeting({
     current: overrides?.speakerId
       ? { topicSpeakers: [], speaker: speakerWith(overrides.speakerId) }
       : { topicSpeakers: [] },
+    queue: { entries, orderedIds: ids, closed: false },
     operational: overrides?.lastAdvancementBy ? { lastAdvancementBy: overrides.lastAdvancementBy } : {},
   });
 }
@@ -223,6 +233,144 @@ describe('useAdvanceAction', () => {
     };
     rerender();
     act(() => vi.advanceTimersByTime(0));
+    expect(result.current.disabled).toBe(false);
+  });
+
+  it('enters cooldown when the next queue entry is deleted (race with Next Speaker click)', () => {
+    // Scenario: chair is about to click Next Speaker to advance to the next
+    // queue entry. Before the server processes the click, the next entry is
+    // deleted (by its owner). Without the cooldown, the chair could skip
+    // past the intended speaker to whoever's now first in line.
+    const socket = makeSocket();
+    const stateRef = {
+      current: {
+        meeting: makeMeeting({ speakerId: 'entry-current', queueIds: ['entry-next', 'entry-after'] }),
+        user: alice,
+      },
+    };
+
+    const { result, rerender } = renderHook(() => useAdvanceAction('queue:next'), {
+      wrapper: makeMutableWrapper(stateRef, socket),
+    });
+
+    expect(result.current.disabled).toBe(false);
+
+    // entry-next is removed; entry-after shifts to position 0
+    stateRef.current = {
+      meeting: makeMeeting({ speakerId: 'entry-current', queueIds: ['entry-after'] }),
+      user: alice,
+    };
+    rerender();
+    act(() => vi.advanceTimersByTime(0));
+
+    expect(result.current.disabled).toBe(true);
+
+    // fire() should be a no-op during cooldown
+    act(() => result.current.fire());
+    expect(socket.emit).not.toHaveBeenCalled();
+
+    // Cooldown clears after 2000ms
+    act(() => vi.advanceTimersByTime(2000));
+    expect(result.current.disabled).toBe(false);
+  });
+
+  it('enters cooldown when a higher-priority entry is inserted at the front of the queue', () => {
+    // E.g. a point-of-order jumps to the front while the chair is reaching
+    // for the Next Speaker button.
+    const socket = makeSocket();
+    const stateRef = {
+      current: {
+        meeting: makeMeeting({ speakerId: 'entry-current', queueIds: ['entry-a', 'entry-b'] }),
+        user: alice,
+      },
+    };
+
+    const { result, rerender } = renderHook(() => useAdvanceAction('queue:next'), {
+      wrapper: makeMutableWrapper(stateRef, socket),
+    });
+
+    stateRef.current = {
+      meeting: makeMeeting({ speakerId: 'entry-current', queueIds: ['entry-poo', 'entry-a', 'entry-b'] }),
+      user: alice,
+    };
+    rerender();
+    act(() => vi.advanceTimersByTime(0));
+
+    expect(result.current.disabled).toBe(true);
+  });
+
+  it('does not enter cooldown when only later queue entries change', () => {
+    // Reordering or deleting entries past position 0 should NOT trigger
+    // cooldown — the next-up entry is unchanged so the button is still safe.
+    const socket = makeSocket();
+    const stateRef = {
+      current: {
+        meeting: makeMeeting({ speakerId: 'entry-current', queueIds: ['entry-next', 'entry-a', 'entry-b'] }),
+        user: alice,
+      },
+    };
+
+    const { result, rerender } = renderHook(() => useAdvanceAction('queue:next'), {
+      wrapper: makeMutableWrapper(stateRef, socket),
+    });
+
+    stateRef.current = {
+      meeting: makeMeeting({ speakerId: 'entry-current', queueIds: ['entry-next', 'entry-b'] }),
+      user: alice,
+    };
+    rerender();
+    act(() => vi.advanceTimersByTime(0));
+
+    expect(result.current.disabled).toBe(false);
+  });
+
+  it('does not enter cooldown when self-advancing through the queue (next entry shifts as expected)', () => {
+    // When the current user advances, both the speaker and the next entry
+    // change — but it's the expected outcome of their own action, so no
+    // cooldown.
+    const socket = makeSocket();
+    const stateRef = {
+      current: {
+        meeting: makeMeeting({ speakerId: 'entry-1', queueIds: ['entry-2', 'entry-3'] }),
+        user: alice,
+      },
+    };
+
+    const { result, rerender } = renderHook(() => useAdvanceAction('queue:next'), {
+      wrapper: makeMutableWrapper(stateRef, socket),
+    });
+
+    // Self-advances: entry-2 becomes the speaker, entry-3 becomes next.
+    stateRef.current = {
+      meeting: makeMeeting({ speakerId: 'entry-2', queueIds: ['entry-3'], lastAdvancementBy: 'alice' }),
+      user: alice,
+    };
+    rerender();
+    act(() => vi.advanceTimersByTime(0));
+
+    expect(result.current.disabled).toBe(false);
+  });
+
+  it('does not enter cooldown for queue changes on meeting:nextAgendaItem', () => {
+    const socket = makeSocket();
+    const stateRef = {
+      current: {
+        meeting: makeMeeting({ speakerId: 'entry-current', queueIds: ['entry-a'] }),
+        user: alice,
+      },
+    };
+
+    const { result, rerender } = renderHook(() => useAdvanceAction('meeting:nextAgendaItem'), {
+      wrapper: makeMutableWrapper(stateRef, socket),
+    });
+
+    stateRef.current = {
+      meeting: makeMeeting({ speakerId: 'entry-current', queueIds: [] }),
+      user: alice,
+    };
+    rerender();
+    act(() => vi.advanceTimersByTime(0));
+
     expect(result.current.disabled).toBe(false);
   });
 

--- a/packages/client/src/hooks/useAdvanceAction.test.tsx
+++ b/packages/client/src/hooks/useAdvanceAction.test.tsx
@@ -274,9 +274,10 @@ describe('useAdvanceAction', () => {
     expect(result.current.disabled).toBe(false);
   });
 
-  it('enters cooldown when a higher-priority entry is inserted at the front of the queue', () => {
-    // E.g. a point-of-order jumps to the front while the chair is reaching
-    // for the Next Speaker button.
+  it('does not enter cooldown when a new entry is inserted ahead of the next-up entry', () => {
+    // A point-of-order jumping to the front shifts the next-up entry, but
+    // the original entry is still in the queue — not a deletion — so the
+    // button stays usable.
     const socket = makeSocket();
     const stateRef = {
       current: {
@@ -296,7 +297,57 @@ describe('useAdvanceAction', () => {
     rerender();
     act(() => vi.advanceTimersByTime(0));
 
-    expect(result.current.disabled).toBe(true);
+    expect(result.current.disabled).toBe(false);
+  });
+
+  it('does not enter cooldown when the queue gains its first entry', () => {
+    // Loading into (or watching) a meeting whose queue fills up from empty
+    // must not disable the button — there was no next-up entry to delete.
+    const socket = makeSocket();
+    const stateRef = {
+      current: {
+        meeting: makeMeeting({ speakerId: 'entry-current', queueIds: [] }),
+        user: alice,
+      },
+    };
+
+    const { result, rerender } = renderHook(() => useAdvanceAction('queue:next'), {
+      wrapper: makeMutableWrapper(stateRef, socket),
+    });
+
+    stateRef.current = {
+      meeting: makeMeeting({ speakerId: 'entry-current', queueIds: ['entry-1'] }),
+      user: alice,
+    };
+    rerender();
+    act(() => vi.advanceTimersByTime(0));
+
+    expect(result.current.disabled).toBe(false);
+  });
+
+  it('does not enter cooldown when the next-up entry is reordered but stays in the queue', () => {
+    // A reorder that pushes a different entry to the front is not a
+    // deletion — the original next-up entry is still queued.
+    const socket = makeSocket();
+    const stateRef = {
+      current: {
+        meeting: makeMeeting({ speakerId: 'entry-current', queueIds: ['entry-a', 'entry-b'] }),
+        user: alice,
+      },
+    };
+
+    const { result, rerender } = renderHook(() => useAdvanceAction('queue:next'), {
+      wrapper: makeMutableWrapper(stateRef, socket),
+    });
+
+    stateRef.current = {
+      meeting: makeMeeting({ speakerId: 'entry-current', queueIds: ['entry-b', 'entry-a'] }),
+      user: alice,
+    };
+    rerender();
+    act(() => vi.advanceTimersByTime(0));
+
+    expect(result.current.disabled).toBe(false);
   });
 
   it('does not enter cooldown when only later queue entries change', () => {

--- a/packages/client/src/hooks/useAdvanceAction.ts
+++ b/packages/client/src/hooks/useAdvanceAction.ts
@@ -7,13 +7,11 @@
  *
  * Includes two layers of protection against accidental double-advancement:
  * - **Debounce** (DEBOUNCE_MS ms): rapid repeated calls are ignored.
- * - **Cooldown** (COOLDOWN_MS ms): after a speaker change attributed to another
- *   user, or a change to the next queue entry (insertion/removal/reorder),
- *   the action is temporarily disabled so the chair can see what's coming up
- *   before advancing. Self-initiated speaker advancements skip the cooldown
- *   (the debounce suffices); changes to the next queue entry always cool down
- *   even when self-initiated, because the chair may have already started
- *   reaching for the button.
+ * - **Cooldown** (COOLDOWN_MS ms): the Next Speaker action is temporarily
+ *   disabled when (a) the speaker changed by another user's hand, or (b) the
+ *   entry that was next-up was *deleted* out of the queue. Either way the
+ *   chair gets a beat to see the new state before advancing. Self-initiated
+ *   speaker advancements skip the cooldown (the debounce suffices).
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -49,88 +47,119 @@ export function useAdvanceAction(event: AdvanceEvent): { fire: (extras?: Advance
 
   const lastFireRef = useRef<number>(0);
 
-  // Timestamp (epoch ms) until which the action is in cooldown.
-  // Checked by fire() directly; the `cooldown` state mirrors it for the UI.
-  const cooldownUntilRef = useRef<number>(0);
+  // Epoch-ms deadline until which the action is in cooldown; 0 means no
+  // cooldown is active. Held in state so the UI re-renders on both edges.
+  const [cooldownUntil, setCooldownUntil] = useState(0);
 
-  // Drive the `disabled` return value for UI feedback.
-  const [cooldown, setCooldown] = useState(false);
   const [debounceActive, setDebounceActive] = useState(false);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   // Track previous values so we can detect changes between renders.
   // `undefined` means we haven't seen any state yet (initial render).
   const prevSpeakerRef = useRef<string | null | undefined>(undefined);
-  const prevNextEntryRef = useRef<string | null | undefined>(undefined);
+  const prevHeadRef = useRef<string | null | undefined>(undefined);
 
-  // Extract primitive values for the effect's dep array. The eslint
-  // react-hooks rule can't reason through nested optional chaining, so
-  // we lift the primitives the effect actually observes.
+  // Every deferred timer this hook schedules, so they can all be cleared on
+  // unmount — otherwise their callbacks leak across tests (fake timers) and
+  // could fire `setState` after the component is gone.
+  const pendingTimersRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
+
+  // Extract values for the effect's dep array. The eslint react-hooks rule
+  // can't reason through nested optional chaining, so we lift what the
+  // effect observes. `queue` is needed to look up entry membership.
   const currentSpeakerId = meeting?.current.speaker?.id ?? null;
-  const nextQueueEntryId = meeting?.queue.orderedIds[0] ?? null;
+  const queue = meeting?.queue;
+  const queueHeadId = queue?.orderedIds[0] ?? null;
   const lastAdvancementBy = meeting?.operational.lastAdvancementBy;
 
-  // Detect speaker advancement or changes to the next queue entry from any
-  // source (server state broadcast). setState is called via setTimeout to
-  // avoid synchronous setState in the effect body (which triggers cascading
-  // renders).
+  // Detect, from incoming server state, the two situations that should
+  // pause the Next Speaker action:
+  //  1. The current speaker changed by someone else's hand (another chair
+  //     advanced, or a reconnect resync) — give the chair a beat to see
+  //     who is now speaking before advancing again.
+  //  2. The entry that was next-up was *deleted* out of the queue (e.g.
+  //     its owner removed it) while the chair may already be reaching for
+  //     the button — without the pause the click would advance to whoever
+  //     shifted into first place. Reordering is excluded (the entry is
+  //     still in the queue) and so is advancement (the speaker changes,
+  //     so it falls under case 1).
   useEffect(() => {
     if (event !== 'queue:next') return;
 
     const prevSpeaker = prevSpeakerRef.current;
-    const prevNext = prevNextEntryRef.current;
-
-    if (prevSpeaker === undefined || prevNext === undefined) {
-      // First render — just record, don't trigger cooldown.
-      prevSpeakerRef.current = currentSpeakerId;
-      prevNextEntryRef.current = nextQueueEntryId;
-      return;
-    }
-
-    const speakerChanged = currentSpeakerId !== prevSpeaker;
-    const nextChanged = nextQueueEntryId !== prevNext;
-
-    if (!speakerChanged && !nextChanged) return;
+    const prevHead = prevHeadRef.current;
 
     prevSpeakerRef.current = currentSpeakerId;
-    prevNextEntryRef.current = nextQueueEntryId;
+    prevHeadRef.current = queueHeadId;
 
-    // Self-initiated speaker advancement skips cooldown — the debounce
-    // alone is sufficient to prevent accidental double-fires. (The next
-    // entry also shifts on self-advance, but that's the expected outcome,
-    // not a surprise the chair needs time to absorb.)
-    if (speakerChanged) {
+    // First state seen — record only, don't trigger cooldown.
+    if (prevSpeaker === undefined || prevHead === undefined) return;
+
+    let shouldCooldown = false;
+    if (currentSpeakerId !== prevSpeaker) {
+      // Speaker advanced. Skip the cooldown when we initiated it
+      // ourselves — the debounce already guards against double-fires.
       const selfInitiated = user != null && lastAdvancementBy === userKey(user);
-      if (selfInitiated) return;
+      shouldCooldown = !selfInitiated;
+    } else if (prevHead !== null && prevHead !== queueHeadId && queue && !(prevHead in queue.entries)) {
+      // Speaker unchanged, but the entry that was next-up is now gone from
+      // the queue entirely — it was deleted. A reorder leaves it present
+      // (just not first); a fresh queue going from empty to populated has
+      // `prevHead === null` and is not a deletion.
+      shouldCooldown = true;
     }
 
-    cooldownUntilRef.current = Date.now() + COOLDOWN_MS;
+    if (!shouldCooldown) return;
 
-    const enableTimer = setTimeout(() => setCooldown(true), 0);
-    const disableTimer = setTimeout(() => {
-      cooldownUntilRef.current = 0;
-      setCooldown(false);
-    }, COOLDOWN_MS);
+    // Defer the `setState` out of the effect body (the lint rule against
+    // cascading renders). This timer is intentionally not cancelled when
+    // the effect re-runs — a burst of deltas must not be able to drop a
+    // cooldown that was legitimately triggered — only on unmount.
+    const deadline = Date.now() + COOLDOWN_MS;
+    const timer = setTimeout(() => {
+      pendingTimersRef.current.delete(timer);
+      setCooldownUntil((prev) => Math.max(prev, deadline));
+    }, 0);
+    pendingTimersRef.current.add(timer);
+  }, [currentSpeakerId, queueHeadId, queue, event, user, lastAdvancementBy]);
 
-    return () => {
-      clearTimeout(enableTimer);
-      clearTimeout(disableTimer);
-    };
-  }, [currentSpeakerId, nextQueueEntryId, event, user, lastAdvancementBy]);
-
-  // Clear the debounce timer on unmount so it doesn't fire `setDebounceActive`
-  // on an unmounted component (happens in tests that click the button and
-  // unmount before DEBOUNCE_MS elapses).
+  // Single timer that ends the cooldown when the deadline passes. Keyed on
+  // `cooldownUntil` so it reschedules when the window is extended and is
+  // left untouched by unrelated re-renders — a per-render timer could be
+  // cleared before it fired, stranding the button permanently disabled.
   useEffect(() => {
+    if (cooldownUntil === 0) return;
+    const pending = pendingTimersRef.current;
+    const timer = setTimeout(
+      () => {
+        pending.delete(timer);
+        setCooldownUntil(0);
+      },
+      Math.max(cooldownUntil - Date.now(), 0),
+    );
+    pending.add(timer);
+    return () => {
+      clearTimeout(timer);
+      pending.delete(timer);
+    };
+  }, [cooldownUntil]);
+
+  // Clear every outstanding timer on unmount so callbacks don't fire
+  // `setState` on a gone component (happens in tests that unmount before a
+  // debounce or cooldown elapses).
+  useEffect(() => {
+    const pending = pendingTimersRef.current;
     return () => {
       clearTimeout(debounceTimerRef.current);
+      for (const timer of pending) clearTimeout(timer);
+      pending.clear();
     };
   }, []);
 
   const fire = useCallback(
     (extras?: AdvanceExtras) => {
       if (!socket || !meeting) return;
-      if (Date.now() < cooldownUntilRef.current) return;
+      if (Date.now() < cooldownUntil) return;
 
       // Debounce only applies to speaker advancement — agenda advancement
       // has its own confirmation dialog and doesn't need rapid-click protection.
@@ -173,8 +202,8 @@ export function useAdvanceAction(event: AdvanceEvent): { fire: (extras?: Advance
         debounceTimerRef.current = setTimeout(() => setDebounceActive(false), DEBOUNCE_MS);
       }
     },
-    [socket, meeting, event],
+    [socket, meeting, event, cooldownUntil],
   );
 
-  return { fire, disabled: cooldown || debounceActive };
+  return { fire, disabled: cooldownUntil > 0 || debounceActive };
 }

--- a/packages/client/src/hooks/useAdvanceAction.ts
+++ b/packages/client/src/hooks/useAdvanceAction.ts
@@ -8,9 +8,12 @@
  * Includes two layers of protection against accidental double-advancement:
  * - **Debounce** (DEBOUNCE_MS ms): rapid repeated calls are ignored.
  * - **Cooldown** (COOLDOWN_MS ms): after a speaker change attributed to another
- *   user is detected in an incoming state update, the action is temporarily
- *   disabled so the chair can see who is now speaking before advancing again.
- *   Self-initiated advancements skip the cooldown (the debounce suffices).
+ *   user, or a change to the next queue entry (insertion/removal/reorder),
+ *   the action is temporarily disabled so the chair can see what's coming up
+ *   before advancing. Self-initiated speaker advancements skip the cooldown
+ *   (the debounce suffices); changes to the next queue entry always cool down
+ *   even when self-initiated, because the chair may have already started
+ *   reaching for the button.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -55,54 +58,65 @@ export function useAdvanceAction(event: AdvanceEvent): { fire: (extras?: Advance
   const [debounceActive, setDebounceActive] = useState(false);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
-  // Track previous speaker ID so we can detect when it changes.
+  // Track previous values so we can detect changes between renders.
   // `undefined` means we haven't seen any state yet (initial render).
   const prevSpeakerRef = useRef<string | null | undefined>(undefined);
+  const prevNextEntryRef = useRef<string | null | undefined>(undefined);
 
   // Extract primitive values for the effect's dep array. The eslint
   // react-hooks rule can't reason through nested optional chaining, so
-  // we lift the two primitives the effect actually observes.
+  // we lift the primitives the effect actually observes.
   const currentSpeakerId = meeting?.current.speaker?.id ?? null;
+  const nextQueueEntryId = meeting?.queue.orderedIds[0] ?? null;
   const lastAdvancementBy = meeting?.operational.lastAdvancementBy;
 
-  // Detect speaker advancement from any source (server state broadcast).
-  // setState is called via setTimeout to avoid synchronous setState in
-  // the effect body (which triggers cascading renders).
+  // Detect speaker advancement or changes to the next queue entry from any
+  // source (server state broadcast). setState is called via setTimeout to
+  // avoid synchronous setState in the effect body (which triggers cascading
+  // renders).
   useEffect(() => {
     if (event !== 'queue:next') return;
 
-    const prevId = prevSpeakerRef.current;
+    const prevSpeaker = prevSpeakerRef.current;
+    const prevNext = prevNextEntryRef.current;
 
-    if (prevId === undefined) {
+    if (prevSpeaker === undefined || prevNext === undefined) {
       // First render — just record, don't trigger cooldown.
       prevSpeakerRef.current = currentSpeakerId;
+      prevNextEntryRef.current = nextQueueEntryId;
       return;
     }
 
-    if (currentSpeakerId !== prevId) {
-      prevSpeakerRef.current = currentSpeakerId;
+    const speakerChanged = currentSpeakerId !== prevSpeaker;
+    const nextChanged = nextQueueEntryId !== prevNext;
 
-      // Skip cooldown for self-initiated advancements — the debounce
-      // alone is sufficient to prevent accidental double-fires.
+    if (!speakerChanged && !nextChanged) return;
+
+    prevSpeakerRef.current = currentSpeakerId;
+    prevNextEntryRef.current = nextQueueEntryId;
+
+    // Self-initiated speaker advancement skips cooldown — the debounce
+    // alone is sufficient to prevent accidental double-fires. (The next
+    // entry also shifts on self-advance, but that's the expected outcome,
+    // not a surprise the chair needs time to absorb.)
+    if (speakerChanged) {
       const selfInitiated = user != null && lastAdvancementBy === userKey(user);
       if (selfInitiated) return;
-
-      cooldownUntilRef.current = Date.now() + COOLDOWN_MS;
-
-      const enableTimer = setTimeout(() => setCooldown(true), 0);
-      const disableTimer = setTimeout(() => {
-        cooldownUntilRef.current = 0;
-        setCooldown(false);
-      }, COOLDOWN_MS);
-
-      return () => {
-        clearTimeout(enableTimer);
-        clearTimeout(disableTimer);
-      };
     }
 
-    return undefined;
-  }, [currentSpeakerId, event, user, lastAdvancementBy]);
+    cooldownUntilRef.current = Date.now() + COOLDOWN_MS;
+
+    const enableTimer = setTimeout(() => setCooldown(true), 0);
+    const disableTimer = setTimeout(() => {
+      cooldownUntilRef.current = 0;
+      setCooldown(false);
+    }, COOLDOWN_MS);
+
+    return () => {
+      clearTimeout(enableTimer);
+      clearTimeout(disableTimer);
+    };
+  }, [currentSpeakerId, nextQueueEntryId, event, user, lastAdvancementBy]);
 
   // Clear the debounce timer on unmount so it doesn't fire `setDebounceActive`
   // on an unmounted component (happens in tests that click the button and


### PR DESCRIPTION
Closes a race where a chair clicks Next Speaker just as the next entry
is being deleted (or another entry jumps to the front), causing the
chair to advance past the intended speaker. The Next Speaker button now
enters the existing 2s cooldown whenever queue.orderedIds[0] changes,
unless the change is the chair's own self-initiated advancement.
